### PR TITLE
fix: Increased test runner's default verbosity level

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -2,6 +2,7 @@ const baseManifest = require('@dazn/kopytko-packager/base-manifest');
 
 module.exports = {
   ...baseManifest,
+  testRunnerVerbosity: 2,
   title: 'Kopytko Unit Testing Framework App',
   ui_resolutions: 'fhd',
 }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-unit-testing-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Increased default test runner verbosity level

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added `testRunnerVerbosity: 2` to the `manifest.js`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

By default unit tests resultw present only summary without information which tests failed:
<img width="275" alt="image" src="https://user-images.githubusercontent.com/37582383/169282288-71bb4c30-7d60-4fc7-a301-050ed331253b.png">

With the verbosity level increased it looks like this:
<img width="738" alt="image" src="https://user-images.githubusercontent.com/37582383/169282635-44879a56-c06b-42fc-ae9a-f048fd325b69.png">

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write documentation (if required)
- [X] Fix linting errors
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
