### PR TITLE
feat: using try catch blocks to avoid unit test crash

### DIFF
--- a/src/components/KopytkoTestSuite.brs
+++ b/src/components/KopytkoTestSuite.brs
@@ -71,7 +71,7 @@ function KopytkoTestSuite() as Object
             result = m.testInstance._func[0](m)
           end if
         catch e
-          sourceObj = e.backtrace[e.backtrace.Count() - 1]
+          sourceObj = e.backtrace[e.backtrace.count() - 1]
           result = Substitute("{0} at {1}", e.message, FormatJson(sourceObj))
         end try
 

--- a/src/components/KopytkoTestSuite.brs
+++ b/src/components/KopytkoTestSuite.brs
@@ -64,11 +64,16 @@ function KopytkoTestSuite() as Object
           end if
         end for
 
-        if (m.testInstance.hasArguments)
-          result = m.testInstance._func[0](m, m.testInstance.arg)
-        else
-          result = m.testInstance._func[0](m)
-        end if
+        try
+          if (m.testInstance.hasArguments)
+            result = m.testInstance._func[0](m, m.testInstance.arg)
+          else
+            result = m.testInstance._func[0](m)
+          end if
+        catch e
+          sourceObj = e.backtrace[e.backtrace.Count() - 1]
+          result = Substitute("{0} at {1}", e.message, FormatJson(sourceObj))
+        end try
 
         for each afterEach in m._afterEach
           if (TF_Utils__IsFunction(afterEach))


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-unit-testing-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #ROKU-790

Using try-catch block while executing test function to avoid test run crash

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Simply using the try-catch block inside `ts.createTest` while executing test function

## How can we verify it:

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write documentation (if required)
- [ ] Fix linting errors
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
