### PR TITLE
feat: adding assert functions like jest

### DIFF
--- a/example/app/components/_tests/assertionExample.test.brs
+++ b/example/app/components/_tests/assertionExample.test.brs
@@ -1,0 +1,269 @@
+' @import /components/KopytkoTestSuite.brs from @dazn/kopytko-unit-testing-framework
+' @mock /components/sum.brs
+
+function TestSuite__assertionExample() as Object
+    ts = KopytkoTestSuite()
+
+    ts.setBeforeEach(sub (ts as Object)
+      m.__mocks = {}
+      m.__mocks.sum = {}
+    end sub)
+  
+    ' ---------------------------------------------------------
+    ' toBeInvalid()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toBeInvalid()", function (ts as Object) as String
+      ' Given
+      value = Invalid
+  
+      ' Then
+      return ts.expect(value).toBeInvalid()
+    end function)
+  
+    ts.addTest("expect(received).not.toBeInvalid()", function (ts as Object) as String
+      ' Given
+      value = "Test Value"
+  
+      ' Then
+      return ts.expect(value).not.toBeInvalid()
+    end function)
+  
+    ' ---------------------------------------------------------
+    ' toBeValid()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toBeValid()", function (ts as Object) as String
+      ' Given
+      value = 2
+  
+      ' Then
+      return ts.expect(value).toBeValid()
+    end function)
+  
+    ts.addTest("expect(received).not.toBeValid()", function (ts as Object) as String
+      ' Given
+      value = Invalid
+  
+      ' Then
+      return ts.expect(value).not.toBeValid()
+    end function)
+  
+    ' ---------------------------------------------------------
+    ' toBeTruthy()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toBeTruthy()", function (ts as Object) as String
+      ' Given
+      value = true
+  
+      ' Then
+      return ts.expect(value).toBeTruthy()
+    end function)
+  
+    ts.addTest("expect(received).not.toBeTruthy()", function (ts as Object) as String
+      ' Given
+      value = false
+  
+      ' Then
+      return ts.expect(value).not.toBeTruthy()
+    end function)
+  
+    ' ---------------------------------------------------------
+    ' toBeFalsy()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toBeFalsy()", function (ts as Object) as String
+      ' Given
+      value = false
+  
+      ' Then
+      return ts.expect(value).toBeFalsy()
+    end function)
+  
+    ts.addTest("expect(received).not.toBeFalsy()", function (ts as Object) as String
+      ' Given
+      value = true
+  
+      ' Then
+      return ts.expect(value).not.toBeFalsy()
+    end function)
+  
+    ' ---------------------------------------------------------
+    ' toBe()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toBe(expected)", function (ts as Object) as String
+      ' Given
+      value = {key: "value"}
+  
+      ' Then
+      return ts.expect(value).toBe({key: "value"})
+    end function)
+  
+    ts.addTest("expect(received).not.toBe(expected)", function (ts as Object) as String
+      ' Given
+      value = 5
+  
+      ' Then
+      return ts.expect(value).not.toBe(4)
+    end function)
+
+    ' ---------------------------------------------------------
+    ' toContain()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toContain(expected)", function (ts as Object) as String
+      ' Given
+      arr = ["value1", "value2", "value3"]
+  
+      ' Then
+      return ts.expect(arr).toContain("value2")
+    end function)
+  
+    ts.addTest("expect(received).not.toContain(expected)", function (ts as Object) as String
+      ' Given
+      arr = ["value1", "value2", "value3"]
+  
+      ' Then
+      return ts.expect(arr).not.toContain("value4")
+    end function)
+
+    ' ---------------------------------------------------------
+    ' toHaveLength()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toHaveLength(expected)", function (ts as Object) as String
+      ' Given
+      arr = ["value1", "value2", "value3"]
+  
+      ' Then
+      return ts.expect(arr).toHaveLength(3)
+    end function)
+  
+    ts.addTest("expect(received).not.toHaveLength(expected)", function (ts as Object) as String
+      ' Given
+      arr = ["value1", "value2", "value3"]
+  
+      ' Then
+      return ts.expect(arr).not.toHaveLength(6)
+    end function)
+
+    ' ---------------------------------------------------------
+    ' toHaveBeenCalled()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toHaveBeenCalled()", function (ts as Object) as String
+      ' When
+      funcCallingSum()
+  
+      ' Then
+      return ts.expect("sum").toHaveBeenCalled()
+    end function)
+
+    ts.addTest("expect(received).not.toHaveBeenCalled()", function (ts as Object) as String
+      ' When
+      funcNotCallingSum()
+  
+      ' Then
+      return ts.expect("sum").not.toHaveBeenCalled()
+    end function)
+
+    ' ---------------------------------------------------------
+    ' toHaveBeenCalledTimes()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toHaveBeenCalledTimes(expected)", function (ts as Object) as String
+      ' When
+      funcCallingSum()
+      funcCallingSum()
+  
+      ' Then
+      return ts.expect("sum").toHaveBeenCalledTimes(2)
+    end function)
+
+    ts.addTest("expect(received).not.toHaveBeenCalledTimes(expected)", function (ts as Object) as String
+      ' When
+      funcCallingSum()
+      funcCallingSum()
+  
+      ' Then
+      return ts.expect("sum").not.toHaveBeenCalledTimes(1)
+    end function)
+
+    ' ---------------------------------------------------------
+    ' toHaveBeenCalledWith()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toHaveBeenCalledWith(expected)", function (ts as Object) as String
+      ' When
+      funcCallingSum(1, 2)
+  
+      ' Then
+      return ts.expect("sum").toHaveBeenCalledWith({ a: 1, b: 2})
+    end function)
+
+    ts.addTest("expect(received).not.toHaveBeenCalledWith(expected)", function (ts as Object) as String
+      ' When
+      funcCallingSum(2, 3)
+  
+      ' Then
+      return ts.expect("sum").not.toHaveBeenCalledWith({ a: 3, b: 2})
+    end function)
+
+    ' ---------------------------------------------------------
+    ' toHaveBeenLastCalledWith()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toHaveBeenLastCalledWith(expected)", function (ts as Object) as String
+      ' When
+      funcCallingSum(1, 2)
+      funcCallingSum(3, 4)
+      funcCallingSum(5, 6)
+  
+      ' Then
+      return ts.expect("sum").toHaveBeenLastCalledWith({ a: 5, b: 6})
+    end function)
+
+    ts.addTest("expect(received).not.toHaveBeenLastCalledWith(expected)", function (ts as Object) as String
+      ' When
+      funcCallingSum(1, 2)
+      funcCallingSum(3, 4)
+      funcCallingSum(5, 6)
+  
+      ' Then
+      return ts.expect("sum").not.toHaveBeenLastCalledWith({ a: 3, b: 4})
+    end function)
+
+    ' ---------------------------------------------------------
+    ' toHaveBeenNthCalledWith()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toHaveBeenNthCalledWith(expected)", function (ts as Object) as String
+      ' When
+      funcCallingSum(1, 2)
+      funcCallingSum(3, 4)
+      funcCallingSum(5, 6)
+  
+      ' Then
+      return ts.expect("sum").toHaveBeenNthCalledWith(2, { a: 3, b: 4})
+    end function)
+
+    ts.addTest("expect(received).not.toHaveBeenNthCalledWith(expected)", function (ts as Object) as String
+      ' When
+      funcCallingSum(1, 2)
+      funcCallingSum(3, 4)
+      funcCallingSum(5, 6)
+  
+      ' Then
+      return ts.expect("sum").not.toHaveBeenNthCalledWith(2, { a: 1, b: 2})
+    end function)
+
+    ' ---------------------------------------------------------
+    ' toThrow()
+    ' ---------------------------------------------------------
+    ts.addTest("expect(received).toThrow()", function (ts as Object) as String
+
+      return ts.expect(function()
+        funcWithException()
+      end function).toThrow()
+    end function)
+  
+    ts.addTest("expect(received).not.toThrow()", function (ts as Object) as String
+  
+      return ts.expect(function()
+        funcWithNoException()
+      end function).not.toThrow()
+    end function)
+  
+    return ts
+  end function
+  

--- a/example/app/components/assertionExample.brs
+++ b/example/app/components/assertionExample.brs
@@ -1,0 +1,15 @@
+' @import /components/sum.brs
+
+function funcWithException()
+    throw "dummy exception!"
+end function
+
+function funcWithNoException()
+end function
+
+function funcCallingSum(aValue = 1 as Integer, bValue = 2 as Integer)
+    value = sum(aValue, bValue)
+end function
+
+function funcNotCallingSum()
+end function

--- a/src/components/KopytkoAssertionMethods.brs
+++ b/src/components/KopytkoAssertionMethods.brs
@@ -1,0 +1,368 @@
+' Assert functions in this file:
+'
+'     kptk_toBeInvalid
+'     kptk_toBeValid
+'     kptk_toBeTruthy
+'     kptk_toBeFalsy
+'     kptk_toBe
+'     kptk_toContain
+'     kptk_toHaveLength
+'     kptk_toHaveBeenCalled
+'     kptk_toHaveBeenCalledTimes
+'     kptk_toHaveBeenCalledWith
+'     kptk_toHaveBeenLastCalledWith
+'     kptk_toHaveBeenNthCalledWith
+'     kptk_toThrow
+'     kptk_not
+
+' ----------------------------------------------------------------
+' To ensure if value is Invalid
+'
+' @return Empty string (if invalid) OR an error message
+' ----------------------------------------------------------------
+function kptk_toBeInvalid() as String
+  MATCHER_NAME = "toBeInvalid()"
+  errorMsg = matcherErrorMessage(MATCHER_NAME, Invalid, m._received, { isNot : m._isNot })
+
+  assertMsg = m._ts.assertInvalid(m._received, errorMsg)
+
+  ' if matcher has been called with expect.not
+  if (m._isNot) then return kptk_utils_ternary(TF_Utils__IsNotEmptyString(assertMsg), "", errorMsg)
+
+  return assertMsg
+end function
+
+' ----------------------------------------------------------------
+' To ensure if value is valid
+'
+' @return Empty string (if valid) OR an error message
+' ----------------------------------------------------------------
+function kptk_toBeValid() as String
+  MATCHER_NAME = "toBeValid()"
+  errorMsg = matcherErrorMessage(MATCHER_NAME, "Value to be valid", m._received, { isNot : m._isNot })
+
+  assertMsg = m._ts.assertNotInvalid(m._received, errorMsg)
+
+  ' if matcher has been called with expect.not
+  if (m._isNot) then return kptk_utils_ternary(TF_Utils__IsNotEmptyString(assertMsg), "", errorMsg)
+
+  return assertMsg
+end function
+
+' ----------------------------------------------------------------
+' To ensure if value is true
+'
+' @return Empty string (if true) OR an error message
+' ----------------------------------------------------------------
+function kptk_toBeTruthy() as String
+  MATCHER_NAME = "toBeTruthy()"
+  errorMsg = matcherErrorMessage(MATCHER_NAME, true, m._received, { isNot : m._isNot })
+
+  assertMsg = m._ts.assertTrue(m._received, errorMsg)
+
+  ' if matcher has been called with expect.not
+  if (m._isNot) then return kptk_utils_ternary(TF_Utils__IsNotEmptyString(assertMsg), "", errorMsg)
+
+  return assertMsg
+end function
+
+' ----------------------------------------------------------------
+' To ensure if value is false
+'
+' @return Empty string (if false) OR an error message
+' ----------------------------------------------------------------
+function kptk_toBeFalsy() as String
+  MATCHER_NAME = "toBeFalsy()"
+  errorMsg = matcherErrorMessage(MATCHER_NAME, false, m._received, { isNot : m._isNot })
+
+  assertMsg = m._ts.assertFalse(m._received, errorMsg)
+
+  ' if matcher has been called with expect.not
+  if (m._isNot) then return kptk_utils_ternary(TF_Utils__IsNotEmptyString(assertMsg), "", errorMsg)
+
+  return assertMsg
+end function
+
+' ----------------------------------------------------------------
+' To ensure if value is eqaul to the expected value
+'
+' @param value (dynamic) - Expected value 
+'
+' @return Empty string (if equal) OR an error message
+' ----------------------------------------------------------------
+function kptk_toBe(value as Dynamic) as String
+  MATCHER_NAME = "toBe(expected)"
+  errorMsg = matcherErrorMessage(MATCHER_NAME, value, m._received, { isNot : m._isNot })
+
+  assertMsg = m._ts.assertEqual(value, m._received)
+
+  ' if matcher has been called with expect.not
+  if (m._isNot) then return kptk_utils_ternary(TF_Utils__IsNotEmptyString(assertMsg), "", errorMsg)
+
+  return kptk_utils_ternary(assertMsg = "", "", errorMsg)
+end function
+
+' ----------------------------------------------------------------
+' To ensure if Array or AssociativeArray contains the expected value
+'
+' @param value (dynamic) - Expected value 
+' @param key (dynamic) - A key name for associative array.
+'
+' @return Empty string (if contains) OR an error message
+' ----------------------------------------------------------------
+function kptk_toContain(value as Dynamic, key = Invalid as Dynamic) as String
+  MATCHER_NAME = "toContain(expected)"
+  errorMsg = matcherErrorMessage(MATCHER_NAME, value, m._received, { isNot : m._isNot })
+
+  assertMsg = m._ts.assertArrayContains(m._received, value, key)
+
+  ' if matcher has been called with expect.not
+  if (m._isNot) then return kptk_utils_ternary(TF_Utils__IsNotEmptyString(assertMsg), "", errorMsg + assertMsg)
+
+  return kptk_utils_ternary(assertMsg = "", "", errorMsg + assertMsg)
+end function
+
+' ----------------------------------------------------------------
+' To ensure if Array or AssociativeArray has expected length
+'
+' @param number (dynamic) - Expected length 
+'
+' @return Empty string (if expected length) OR an error message
+' ----------------------------------------------------------------
+function kptk_toHaveLength(number as Dynamic) as String
+  MATCHER_NAME = "toHaveLength(expected)"
+  errorMsg = matcherErrorMessage(MATCHER_NAME, number, m._received, { isNot : m._isNot })
+
+  assertMsg = m._ts.assertArrayCount(m._received, number)
+
+  ' if matcher has been called with expect.not
+  if (m._isNot) then return kptk_utils_ternary(TF_Utils__IsNotEmptyString(assertMsg), "", errorMsg + assertMsg)
+
+  return kptk_utils_ternary(assertMsg = "", "", errorMsg + assertMsg)
+end function
+
+' ----------------------------------------------------------------
+' To ensure if a mock function was called at least once
+'
+' @return Empty string (if called) OR an error message
+' ----------------------------------------------------------------
+function kptk_toHaveBeenCalled() as String
+  MATCHER_NAME = "toHaveBeenCalled()"
+  EXPECTED_STR = "Expected number of calls"
+  RECEIVED_STR = "Received number of calls"
+  
+  methodMock = m._ts.getProperty(GetGlobalAA().__mocks, m._received, { calls: [] })
+  numberOfCalls = 0
+  
+  if (TF_Utils__IsValid(methodMock.calls))
+    numberOfCalls = methodMock.calls.count()
+  end if
+ 
+  passed = (numberOfCalls > 0)
+  ' if matcher has been called with expect.not
+  passed = kptk_utils_ternary(m._isNot, NOT passed, passed)
+
+  return kptk_utils_ternary(passed, "", matcherErrorMessage(MATCHER_NAME, ">=1", numberOfCalls, { isNot : m._isNot }, EXPECTED_STR, RECEIVED_STR))
+end function
+
+' ----------------------------------------------------------------
+' To ensure if a mock function was called exact number of times
+'
+' @param number (integer) - Expected number of mock function calls
+'
+' @return empty string (if called) OR an error message
+' ----------------------------------------------------------------
+function kptk_toHaveBeenCalledTimes(number as Integer) as String
+  MATCHER_NAME = "toHaveBeenCalledTimes(expected)"
+  EXPECTED_STR = "Expected number of calls"
+  RECEIVED_STR = "Received number of calls"
+
+  methodMock = m._ts.getProperty(GetGlobalAA().__mocks, m._received, { calls: [] })
+  numberOfCalls = 0
+  
+  if (TF_Utils__IsValid(methodMock.calls))
+    numberOfCalls = methodMock.calls.count()
+  end if
+
+  passed = (numberOfCalls = number)
+  ' if matcher has been called with expect.not
+  passed = kptk_utils_ternary(m._isNot, NOT passed, passed)
+
+  return kptk_utils_ternary(passed, "", matcherErrorMessage(MATCHER_NAME, number, numberOfCalls, { isNot : m._isNot }, EXPECTED_STR, RECEIVED_STR))
+end function
+
+' ----------------------------------------------------------------
+' To ensure if a mock function was called with specific arguments
+'
+' @param params (object) - Expected arguments
+'
+' @return empty string (if called) OR an error message
+' ----------------------------------------------------------------
+function kptk_toHaveBeenCalledWith(params as Object) as String
+  MATCHER_NAME = "toHaveBeenCalledWith(expected)"
+
+  methodMock = m._ts.getProperty(GetGlobalAA().__mocks, m._received, { calls: [] })
+  methodMockCalls = []
+  callsParams = []
+  
+  if (TF_Utils__IsValid(methodMock.calls))
+    methodMockCalls = methodMock.calls
+  end if
+
+  numberOfCalls = methodMockCalls.count()
+
+  for each methodCall in methodMockCalls
+    callsParams.push(methodCall.params)
+    if (m._ts.eqValues(methodCall.params, params))
+      passed = true
+      exit for
+    else
+      passed = false
+    end if
+  end for
+
+  ' if matcher has been called with expect.not
+  passed = kptk_utils_ternary(m._isNot, NOT passed, passed)
+
+  return kptk_utils_ternary(passed, "", matcherErrorMessage(MATCHER_NAME, params, callsParams, { isNot : m._isNot }) + Substitute("Number of calls: {0}", kptk_utils_asString(numberOfCalls)))
+end function
+
+
+' ----------------------------------------------------------------
+' To ensure if a mock function was last called with specific arguments
+'
+' @param params (object) - Expected arguments
+'
+' @return empty string (if called) OR an error message
+' ----------------------------------------------------------------
+function kptk_toHaveBeenLastCalledWith(params as Object) as String
+  MATCHER_NAME = "toHaveBeenLastCalledWith(expected)"
+
+  methodMock = m._ts.getProperty(GetGlobalAA().__mocks, m._received, { calls: [] })
+  numberOfCalls = methodMock.calls.count()
+  actualParams = Invalid
+  passed = false
+
+  if (numberOfCalls > 0)
+    ' check if last call of the function made with expected params
+    lastCall = methodMock.calls[numberOfCalls - 1]
+    actualParams = lastCall.params
+    passed = m._ts.eqValues(actualParams, params)
+  end if
+
+  ' if matcher has been called with expect.not
+  passed = kptk_utils_ternary(m._isNot, NOT passed, passed)
+
+  return kptk_utils_ternary(passed, "", matcherErrorMessage(MATCHER_NAME, params, actualParams, { isNot : m._isNot }) + Substitute("Number of calls: {0}", kptk_utils_asString(numberOfCalls)))
+end function
+
+' ----------------------------------------------------------------
+' To ensure if a mock function was last called with specific arguments
+'
+' @param nthCall (Integer) - Call index which needs to be checked
+' @param params (object) - Expected arguments
+'
+' @return empty string (if called) OR an error message
+' ----------------------------------------------------------------
+function kptk_toHaveBeenNthCalledWith(nthCall as Integer, params as Object) as String
+  MATCHER_NAME = "toHaveBeenNthCalledWith(expected)"
+
+  methodMock = m._ts.getProperty(GetGlobalAA().__mocks, m._received, { calls: [] })
+  numberOfCalls = methodMock.calls.count()
+  actualParams = Invalid
+  passed = false
+
+  if (numberOfCalls > 0)
+    ' check if nth call of the function made with expected params
+    methodNthCall = methodMock.calls[nthCall - 1]
+    actualParams = methodNthCall.params
+    passed = m._ts.eqValues(actualParams, params)
+  end if
+
+  ' if matcher has been called with expect.not
+  passed = kptk_utils_ternary(m._isNot, NOT passed, passed)
+
+  return kptk_utils_ternary(passed, "", matcherErrorMessage(MATCHER_NAME, params, actualParams, { isNot : m._isNot }) + Substitute("Number of calls: {0}", kptk_utils_asString(numberOfCalls)))
+end function
+
+' ----------------------------------------------------------------
+' To ensure if a function throws an exception
+' Must wrap the code which needs to be asserted in a function, otherwise the error will not be caught and the assertion will fail.
+'
+' @return empty string (if throws) OR an error message
+' ----------------------------------------------------------------
+function kptk_toThrow()
+  ' return error if received value is not a function
+  if (NOT TF_Utils__IsFunction(m._received)) then return "Received value must be a function"
+
+  MATCHER_NAME = "toThrow()"
+  passed = false
+
+  try
+    m._received()
+  catch e
+    passed = true
+  end try
+
+  ' if matcher has been called with expect.not
+  passed = kptk_utils_ternary(m._isNot, NOT passed, passed)
+
+  return kptk_utils_ternary(passed, "", matcherErrorMessage(MATCHER_NAME, "throws", e, { isNot : m._isNot }))
+end function
+
+' ----------------------------------------------------------------
+' If you know how to test something, .not lets you test its opposite
+'
+' @param this (object) - An expect object in which reference it should be called
+'
+' @return Expect object with '_isNot' value as 'true'
+' ----------------------------------------------------------------
+function kptk_not(this as Object) as Object
+  notExpect = {}
+  notExpect.append(this)
+  notExpect.addReplace("_isNot", true)
+  return notExpect
+end function
+
+' ----------------------------------------------------------------
+' Utils
+' ----------------------------------------------------------------
+
+function matcherErrorMessage(matcherName as String, expected = Invalid as Dynamic, actual = Invalid as Dynamic, options = {} as Object, expectedString = "Expected" as String, receivedString = "Received" as String) as String
+  TRAILING_STR = " ; "
+  isNot = (options.isNot <> Invalid AND options.isNot)
+  ' format matcher name
+  matcherString = "expect(received)" + kptk_utils_ternary(isNot, ".not", "") + "." + matcherName + " - "
+
+  if (TF_Utils__IsNotEmptyString(expectedString))
+    ' format expected string
+    matcherString += Substitute("{0}: {1} {2}", expectedString, kptk_utils_ternary(isNot, "[not]", ""), kptk_utils_asString(expected)) + TRAILING_STR
+  end if
+
+  if (TF_Utils__IsNotEmptyString(receivedString))
+    ' format received string
+    matcherString += Substitute("{0}: {1}", receivedString, kptk_utils_asString(actual)) + TRAILING_STR
+  end if
+
+  return matcherString
+end function
+
+function kptk_utils_asString(value as Dynamic) as String
+  if (not TF_Utils__IsValid(value))
+    return "Invalid"
+  else if (TF_Utils__IsValid(GetInterface(value, "ifToStr")))
+    return value.toStr()
+  else if (TF_Utils__IsValid(GetInterface(value, "ifAssociativeArray")) OR TF_Utils__IsValid(GetInterface(value, "ifArray")))
+    return FormatJson(value)
+  else
+    return ""
+  end if
+end function
+
+function kptk_utils_ternary(conditionResult as Boolean, trueReturnValue as Dynamic, falseReturnValue as Dynamic) as Dynamic
+  if (conditionResult)
+    return trueReturnValue
+  end if
+
+  return falseReturnValue
+end function

--- a/src/components/KopytkoTestSuite.brs
+++ b/src/components/KopytkoTestSuite.brs
@@ -1,4 +1,5 @@
 ' @import /source/UnitTestFramework.brs
+' @import /components/KopytkoAssertionMethods.brs
 function KopytkoTestSuite() as Object
   ts = BaseTestSuite()
 
@@ -304,6 +305,44 @@ function KopytkoTestSuite() as Object
     end for
 
     return Invalid
+  end function
+
+  ' ----------------------------------------------------------------
+  ' The expect function is used every time you want to test a value. 
+  ' You will rarely call expect by itself. 
+  ' Instead, you will use expect along with a "matcher" function to assert something about a value
+
+  ' @param value (dynamic) - Value which needs to be asserted
+
+  ' @return An object having all the assertion/ matcher methods
+  ' ----------------------------------------------------------------
+  ts.expect = function (value as Dynamic) as Object
+    context = {}
+    context._ts = m
+    context._received = Invalid
+    context._isNot = false
+
+    ' assign received value if received value is initialized and valid
+    if (TF_Utils__IsValid(value)) then context._received = value
+
+    ' matcher functions
+    context.toBe = kptk_toBe
+    context.toBeFalsy = kptk_toBeFalsy
+    context.toBeInvalid = kptk_toBeInvalid
+    context.toBeTruthy = kptk_toBeTruthy
+    context.toBeValid = kptk_toBeValid
+    context.toContain = kptk_toContain
+    context.toHaveBeenCalled = kptk_toHaveBeenCalled
+    context.toHaveBeenCalledTimes = kptk_toHaveBeenCalledTimes
+    context.toHaveBeenCalledWith = kptk_toHaveBeenCalledWith
+    context.toHaveBeenLastCalledWith = kptk_toHaveBeenLastCalledWith
+    context.toHaveBeenNthCalledWith = kptk_toHaveBeenNthCalledWith
+    context.toHaveLength = kptk_toHaveLength
+    context.toThrow = kptk_toThrow
+
+    context.not = kptk_not(context)
+
+    return context
   end function
 
   return ts


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-unit-testing-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #ROKU-1408

Implementing the assert functions like we have in Jest.

## How did you implement it:

Most of the new assert functions are using already available test methods from BrightScript or Kopytko framework. Some changes in the error message when test case fails.

## How can we verify it:
Unit tests are available at -
`/example/app/components/_tests/assertionExample.test.brs`

## Todos:

- [ ] Write documentation (if required)
- [ ] Fix linting errors
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
