### PR TITLE
fix: Ignoring Invalid elements when calculating elements' index in children array

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,18 @@ build: some description.
 chore: some description.
 ```
 
+# Unit tests
+Please cover any changes in unit tests.
+They are running via Kopytko Packager, so to be able to run them, create .env file in the root directory (it's git-ignored) with following fields:
+```
+ROKU_IP=<Roku device IP>
+ROKU_DEV_PASSWORD=<Roku device dev mode password>
+ROKU_USER=<Roku device dev mode user>
+```
+More info: https://github.com/getndazn/kopytko-packager#env-file
+
+Run unit tests using `npm test` command.
+
 # Our Code of Conduct
 
 Finally, to make sure you have a pleasant experience while being in our welcoming community, please read our [code of conduct](CODE_OF_CONDUCT.md). It outlines our core values and believes and will make working together a happier experience.

--- a/src/components/renderer/KopytkoDiffUtility.brs
+++ b/src/components/renderer/KopytkoDiffUtility.brs
@@ -1,0 +1,143 @@
+' @import /components/Assert.brs from @dazn/kopytko-utils
+function KopytkoDiffUtility() as Object
+  prototype = {}
+  prototype._assert = Assert()
+
+  ' Diffs the current virtual DOM against the new one, returning an object with the elements that need to be
+  ' updated, rendered or removed.
+  ' @param {Object} currentVirtualDOM - The current virtual DOM
+  ' @param {Object} newVirtualDOM - The new virtual DOM
+  ' @returns {Object} diffResult - The diff result object
+  ' @returns {Object} diffResult.elementsToUpdate - vNodes containing the props that needs to be updated
+  ' @returns {Object[]} diffResult.elementsToRender - A list of vNodes to render
+  ' @returns {String[]} diffResult.elementsToRemove - A list of the IDs of elements to remove from the DOM
+  prototype.diffDOM = function (currentVirtualDOM as Object, newVirtualDOM as Object) as Object
+    m._diffResult = {
+      elementsToUpdate: {},
+      elementsToRender: [],
+      elementsToRemove: [],
+    }
+
+    if (Type(currentVirtualDOM) = "roArray" AND (newVirtualDOM = Invalid OR Type(newVirtualDOM) = "roArray"))
+      m._diffElementChildren(currentVirtualDOM, newVirtualDOM)
+    else
+      m._diffElement(currentVirtualDOM, newVirtualDOM)
+    end if
+
+    diffResult = m._diffResult
+    m.delete("_diffResult")
+
+    return diffResult
+  end function
+
+  ' @private
+  prototype._diffElement = sub (currentElement as Object, newElement as Object)
+    if (currentElement = Invalid AND newElement = Invalid)
+      return
+    end if
+
+    if (currentElement = Invalid AND newElement <> Invalid)
+      m._diffResult.elementsToRender.push(newElement)
+
+      return
+    end if
+
+    if (currentElement <> Invalid AND newElement = Invalid)
+      m._markElementToBeRemoved(currentElement)
+
+      return
+    end if
+
+    if (Type(currentVirtualDOM) <> Type(newVirtualDOM))
+      print "DOM type should not be changed"
+
+      return
+    end if
+
+    if (currentElement.name <> newElement.name OR currentElement.props.id <> newElement.props.id)
+      m._diffResult.elementsToRender.push(newElement)
+      m._markElementToBeRemoved(currentElement)
+
+      return
+    end if
+
+    m._diffExistingElement(currentElement, newElement)
+  end sub
+
+  ' @todo Support elements reordering
+  ' @private
+  prototype._diffElementChildren = sub (currentChildren as Object, newChildren as Object, parentElementId = Invalid as Dynamic)
+    if (newChildren = Invalid) then newChildren = []
+
+    currentChildrenMapped = {}
+    if (currentChildren <> Invalid)
+      for each currentChild in currentChildren
+        if (currentChild <> Invalid)
+          currentChildrenMapped[currentChild.props.id] = currentChild
+        end if
+      end for
+    end if
+
+    nonInvalidNewChildIndex = 0
+    for each newChild in newChildren
+      if (newChild <> Invalid)
+        newChild.index = nonInvalidNewChildIndex
+        nonInvalidNewChildIndex++
+        newChild.parentId = parentElementId
+
+        if (currentChildrenMapped[newChild.props.id] = Invalid)
+          m._diffResult.elementsToRender.push(newChild)
+        else
+          m._diffExistingElement(currentChildrenMapped[newChild.props.id], newChild)
+          currentChildrenMapped.delete(newChild.props.id)
+        end if
+      end if
+    end for
+
+    for each currentChildIdToRemove in currentChildrenMapped
+      m._markElementToBeRemoved(currentChildrenMapped[currentChildIdToRemove])
+    end for
+  end sub
+
+  prototype._diffExistingElement = sub (currentElement as Object, newElement as Object)
+    if (newElement.dynamicProps = Invalid)
+      newElement.dynamicProps = {}
+    end if
+
+    m._diffElementProps(currentElement.props.id, currentElement.dynamicProps, newElement.dynamicProps)
+    if currentElement.children <> Invalid OR newElement.children <> Invalid
+      m._diffElementChildren(currentElement.children, newElement.children, newElement.props.id)
+    end if
+  end sub
+
+  ' @private
+  prototype._markElementToBeRemoved = sub (element as Object)
+    m._diffResult.elementsToRemove.push(element.props.id)
+
+    if (element.children = Invalid OR element.children.count() = 0)
+      return
+    end if
+
+    for each child in element.children
+      if (child <> Invalid)
+        m._markElementToBeRemoved(child)
+      end if
+    end for
+  end sub
+
+  ' @private
+  prototype._diffElementProps = sub (elementId as String, currentProps as Object, newProps as Object)
+    for each newProp in newProps
+      if (NOT m._assert.deepEqual(currentProps[newProp], newProps[newProp]))
+        ' Create element key in case it doesn't exist yet
+        if (m._diffResult.elementsToUpdate[elementId] = Invalid)
+          m._diffResult.elementsToUpdate[elementId] = { props: {} }
+        end if
+
+        m._diffResult.elementsToUpdate[elementId].props[newProp] = newProps[newProp]
+      end if
+    end for
+  end sub
+
+  return prototype
+end function

--- a/src/components/renderer/_tests/kopytkoDiffUtility/KopytkoDiffUtility_Main.test.brs
+++ b/src/components/renderer/_tests/kopytkoDiffUtility/KopytkoDiffUtility_Main.test.brs
@@ -1,0 +1,679 @@
+function TestSuite__KopytkoDiffUtility_Main()
+  ts = KopytkoFrameworkTestSuite()
+  ts.name = "KopytkoDiffUtility - diffDOM"
+  ts.kopytkoDiffUtility = KopytkoDiffUtility()
+
+  ts.addTest("it returns the proper diff result structure", function (ts as Object) as String
+    ' Given
+    vNode = {
+      name: "Label",
+      props: { id: "testLabel" },
+    }
+
+    newVNode = {
+      name: "Label",
+      props: { id: "testLabel" },
+    }
+
+    ' When
+    diffResult = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode)
+
+    ' Then
+    expectedKeys = ["elementsToUpdate", "elementsToRender", "elementsToRemove"]
+
+    return ts.assertAAHasKeys(diffResult, expectedKeys, "The diff result does not have the expected keys")
+  end function)
+
+  ts.addTest("it does not mark anything to be removed, rendered or updated if the new vNode did not change", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+    ])
+
+    ' When
+    diffResult = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode)
+
+    ' Then
+    expectedResult = {
+      elementsToUpdate: {},
+      elementsToRender: [],
+      elementsToRemove: [],
+    }
+
+    return ts.assertEqual(diffResult, expectedResult, "The diff result is different than expected")
+  end function)
+
+  ts.addTest("it marks an element to be removed when the new element does not exist", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+      {
+        name: "Label",
+        props: { id: "label2" },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+    ])
+
+    ' When
+    elementsToRemove = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToRemove
+
+    ' Then
+    return ts.assertArrayContains(elementsToRemove, "label2", "The removed element was not marked to be removed")
+  end function)
+
+  ts.addTest("it marks an element to be removed when the new element is invalid", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+      {
+        name: "Label",
+        props: { id: "label2" },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+      Invalid,
+    ])
+
+    ' When
+    elementsToRemove = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToRemove
+
+    ' Then
+    return ts.assertArrayContains(elementsToRemove, "label2", "The invalid element was not marked to be removed")
+  end function)
+
+  ts.addTest("it marks all element's children to be removed when the new element is invalid", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        children: [
+          {
+            name: "Label",
+            props: { id: "label2" },
+            children: [
+              {
+                name: "Label",
+                props: { id: "label3" },
+              },
+            ],
+          },
+          {
+            name: "Label",
+            props: { id: "label4" },
+          },
+        ],
+      },
+      {
+        name: "Label",
+        props: { id: "label5" },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      Invalid,
+      {
+        name: "Label",
+        props: { id: "label5" },
+      },
+    ])
+
+    ' When
+    elementsToRemove = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToRemove
+
+    ' Then
+    actualMarkedElements = elementsToRemove
+    expectedMarkedElements = ["label1", "label2", "label3", "label4"]
+
+    return ts.assertEqual(actualMarkedElements, expectedMarkedElements, "The elements were not marked to be removed")
+  end function)
+
+  ts.addTest("it marks an element to be rendered when the element did not exist and there is a new one in its position", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+      {
+        name: "Label",
+        props: { id: "label2" },
+      },
+    ])
+
+    ' When
+    diffResult = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode)
+    labelToRender = diffResult.elementsToRender[0]
+    expectedLabelToRender = {
+      name: "Label",
+      props: { id: "label2" },
+      parentid: "root",
+      index: 1,
+    }
+
+    ' Then
+    return ts.assertEqual(labelToRender, expectedLabelToRender, "The new element was not marked to be rendered")
+  end function)
+
+  ts.addTest("it marks an element to be rendered when the element was invalid and there is a new one in its position", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+      Invalid,
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+      {
+        name: "Label",
+        props: { id: "label2" },
+      },
+    ])
+
+    ' When
+    diffResult = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode)
+    labelToRender = diffResult.elementsToRender[0]
+    expectedLabelToRender = {
+      name: "Label",
+      props: { id: "label2" },
+      parentid: "root",
+      index: 1,
+    }
+
+    ' Then
+    return ts.assertEqual(labelToRender, expectedLabelToRender, "The new element was not marked to be rendered")
+  end function)
+
+  ts.addTest("it ignores Invalid elements when calculating element's index", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      Invalid,
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+      Invalid,
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      Invalid
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+      {
+        name: "Label",
+        props: { id: "label2" },
+      },
+    ])
+
+    ' When
+    diffResult = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode)
+    labelToRender = diffResult.elementsToRender[0]
+
+    ' Then
+    return ts.assertEqual(labelToRender.index, 1)
+  end function)
+
+  ts.addTest("it marks an element to be removed and another to be rendered when they have the same name but different IDs", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "newLabel" },
+      },
+    ])
+
+    ' When
+    diffResult = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode)
+    expectedResult = {
+      elementsToUpdate: {},
+      elementsToRender: [newVNode.children[0]],
+      elementsToRemove: ["label1"],
+    }
+
+    ' Then
+    return ts.assertEqual(diffResult, expectedResult, "The elements were not marked as expected")
+  end function)
+
+  ts.addTest("it marks an element to be removed and another to be rendered when the compared elements names are different", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "DaznButton",
+        props: { id: "button1" },
+      },
+    ])
+
+    ' When
+    diffResult = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode)
+    expectedResult = {
+      elementsToUpdate: {},
+      elementsToRender: [newVNode.children[0]],
+      elementsToRemove: ["label1"],
+    }
+
+    ' Then
+    return ts.assertEqual(diffResult, expectedResult, "The elements were not marked as expected")
+  end function)
+
+  ts.addTest("it marks the element invalid props to be updated if they changed to a valid value", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { text: Invalid },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { text: "some text" },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { text: "some text" },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The changed props were not marked to be updated")
+  end function)
+
+  ts.addTest("it doesn't mark the element prop to be updated if the changed prop is in the `props` property", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1", text: Invalid },
+        dynamicProps: { visible: false },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1", text: "some text" },
+        dynamicProps: { visible: true },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { visible: true }, ' Doesn't include the text prop
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate)
+  end function)
+
+  ts.addTest("it marks the element valid props to be updated if they changed to an invalid value", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { text: "some text" },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { text: Invalid },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { text: Invalid },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The changed props were not marked to be updated")
+  end function)
+
+  ts.addTest("it marks the element primitive type props to be updated if they changed", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { text: "some text" },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { text: "different text" },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { text: "different text" },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The changed props were not marked to be updated")
+  end function)
+
+  ts.addTest("it marks the element array props to be updated if they have different count number", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1", customProp: [1, 2, 3] },
+        dynamicProps: { customProp: [1, 2, 3] },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: [1, 2, 3, 4] },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { customProp: [1, 2, 3, 4] },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The array prop was not marked to be updated")
+  end function)
+
+  ts.addTest("it marks the element array props to be updated if they have different primitive type props", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: [1, 2, 3] },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: [4, 1, 3] },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { customProp: [4, 1, 3] },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The array prop was not marked to be updated")
+  end function)
+
+  ts.addTest("it marks the element array props to be updated if they have different array type values", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: [[1, 2], [2, 4]] },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: [[2, 1], [6, 3]] },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { customProp: [[2, 1], [6, 3]] },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The array prop was not marked to be updated")
+  end function)
+
+  ts.addTest("it marks the element array props to be updated if they have different associative array type values", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: [{ id: 1 }, { id: 2 }] },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: [{ id: 4 }, { id: 9 }] },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { customProp: [{ id: 4 }, { id: 9 }] },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The array prop was not marked to be updated")
+  end function)
+
+  ts.addTest("it marks the element associative array props to be updated if they have different count of keys", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: { key1: 1 } },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: { key1: 1, key2: 2 } },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { customProp: { key1: 1, key2: 2 } },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The associative array prop was not marked to be updated")
+  end function)
+
+  ts.addTest("it marks the element associative array props to be updated if they have different primitive type key values", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: { id: 1 } },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: { id: 4 } },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { customProp: { id: 4 } },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The associative array prop was not marked to be updated")
+  end function)
+
+  ts.addTest("it marks the element associative array props to be updated if they have different array type key values", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: { arr: [1, 2, 3] } },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: { arr: [1, 2] } },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { customProp: { arr: [1, 2] } },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The associative array prop was not marked to be updated")
+  end function)
+
+  ts.addTest("it marks the element associative array props to be updated if they have different associative array type key values", function (ts as Object) as String
+    ' Given
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: { aa: { id: 1 } } },
+      },
+    ])
+
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: { aa: { id: 2 } } },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    expectedElementToUpdate = {
+      props: { customProp: { aa: { id: 2 } } },
+    }
+
+    ' Then
+    return ts.assertEqual(elementToUpdate, expectedElementToUpdate, "The associative array prop was not marked to be updated")
+  end function)
+
+  ts.addTest("it marks the element node props to be updated if they have different pointers", function (ts as Object) as String
+    ' Given
+    currentNodeProp = CreateObject("roSGNode", "ContentNode")
+    vNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: currentNodeProp },
+      },
+    ])
+
+    newNodeProp = CreateObject("roSGNode", "ContentNode")
+    newVNode = TestUtil_createRootElementWithChildren([
+      {
+        name: "Label",
+        props: { id: "label1" },
+        dynamicProps: { customProp: newNodeProp },
+      },
+    ])
+
+    ' When
+    elementToUpdate = ts.kopytkoDiffUtility.diffDOM(vNode, newVNode).elementsToUpdate.label1
+    isTheExpectedProp = elementToUpdate.props.customProp.isSameNode(newNodeProp)
+
+    ' Then
+    return ts.assertTrue(isTheExpectedProp, "The node prop was not marked to be updated")
+  end function)
+
+  return ts
+end function


### PR DESCRIPTION
## What did you implement:

Fixed incorrect children insertion if children array contains Invalid elements

## How did you implement it:

By differently comparing current and new children arrays

## How can we verify it:

Unit tests

## Todos:

- [x ] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
