### PR TITLE
feat: Adding index to the name of a parameterized test

### DIFF
--- a/src/components/KopytkoTestSuite.brs
+++ b/src/components/KopytkoTestSuite.brs
@@ -57,6 +57,7 @@ function KopytkoTestSuite() as Object
   end sub
 
   ts.addParameterizedTests = sub (paramsList as Object, testName as String, testFunction as Function)
+    index = 0
     for each param in paramsList
       parsedTestName = testName
 
@@ -74,7 +75,10 @@ function KopytkoTestSuite() as Object
         parsedTestName = Substitute(parsedTestName, "")
       end if
 
+      if (parsedTestName = testName) then parsedTestName += " #" + index.toStr()
+
       m.addTest(parsedTestName, testFunction, Invalid, Invalid, param, true)
+      index++
     end for
   end sub
 

--- a/src/components/KopytkoTestSuite.brs
+++ b/src/components/KopytkoTestSuite.brs
@@ -57,7 +57,7 @@ function KopytkoTestSuite() as Object
   end sub
 
   ts.addParameterizedTests = sub (paramsList as Object, testName as String, testFunction as Function)
-    index = 0
+    index = 1
     for each param in paramsList
       parsedTestName = testName
 
@@ -75,7 +75,7 @@ function KopytkoTestSuite() as Object
         parsedTestName = Substitute(parsedTestName, "")
       end if
 
-      if (parsedTestName = testName) then parsedTestName += " #" + index.toStr()
+      parsedTestName += " #" + index.toStr()
 
       m.addTest(parsedTestName, testFunction, Invalid, Invalid, param, true)
       index++


### PR DESCRIPTION
## What did you implement:

Currently the framework allows using params of a parameterized test in the test name but if not used, developer doesn't know which version of a parameterized test failed in case of a complex param.

## How did you implement it:

If the test name remained the same after interpolating params, code adds `#{index}` to the end of the unit test name.

## How can we verify it:

Run any parameterized test without a use of params in the name

Example screenshot:
![image](https://user-images.githubusercontent.com/1011926/218082751-25412efe-0d02-4180-a952-c9f0edd44c55.png)


## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
