### PR TITLE
feat: add properties mocking methods to mockFunction

### DIFF
--- a/docs/api/KopytkoMockFunction.md
+++ b/docs/api/KopytkoMockFunction.md
@@ -15,10 +15,13 @@ mockFunction("Service.serviceMethod")
   - [`clear`](#clear)
   - [`getCalls`](#getcalls)
   - [`getContructorCalls`](#getcontructorcalls)
+  - [`getConstructorCalls`](#getconstructorcalls)
   - [`implementation`](#implementation)
   - [`returnValue`](#returnvalue)
   - [`resolvedValue`](#resolvedvalue)
   - [`rejectedValue`](#rejectedvalue)
+  - [`setProperties`](#setproperties)
+  - [`setProperty`](#setproperty)
   - [`throw`](#throw)
 
 ## Methods
@@ -43,12 +46,24 @@ calls = mockFunction("functionName").getCalls()
 
 ### `getContructorCalls`
 
+! [DEPRECATED] This method name has been misspelled and will be removed in the future
+
 Returns an array with all function mock constructor calls,
 
 remember that all calls are cleared before each test case execution.
 
 ```brs
 contructorCalls = mockFunction("functionName").getContructorCalls()
+```
+
+### `getConstructorCalls`
+
+Returns an array with all function mock constructor calls,
+
+remember that all calls are cleared before each test case execution.
+
+```brs
+constructorCalls = mockFunction("functionName").getConstructorCalls()
 ```
 
 ### `implementation`
@@ -96,6 +111,30 @@ It mocks function promise rejected value
 ```brs
 mockFunction("functionName").rejectedValue("error message")
 ```
+
+### `setProperties`
+
+It mocks multiple properties of the object returned by the function.
+
+```brs
+mockFunction("functionName").setProperties({
+  propertyName: "propertyValue",
+  yetAnotherPropertyName: 123.33,
+})
+```
+
+And further in the test `functionName().propertyName` will be set to `"propertyValue"`,
+`functionName().yetAnotherPropertyName` to 123.33.
+
+### `setProperty`
+
+It mocks the property of the object returned by the function.
+
+```brs
+mockFunction("functionName").setProperty("propertyName", "propertyValue")
+```
+
+And further in the test `functionName().propertyName` will be set to `"propertyValue"`.
 
 ### `throw`
 

--- a/docs/api/KopytkoMockFunction.md
+++ b/docs/api/KopytkoMockFunction.md
@@ -14,7 +14,6 @@ mockFunction("Service.serviceMethod")
 - [Methods](#methods)
   - [`clear`](#clear)
   - [`getCalls`](#getcalls)
-  - [`getContructorCalls`](#getcontructorcalls)
   - [`getConstructorCalls`](#getconstructorcalls)
   - [`implementation`](#implementation)
   - [`returnValue`](#returnvalue)
@@ -46,7 +45,7 @@ calls = mockFunction("functionName").getCalls()
 
 ### `getContructorCalls`
 
-! [DEPRECATED] This method name has been misspelled and will be removed in the future
+**! [DEPRECATED]** This method name has been misspelled and will be removed in the future
 
 Returns an array with all function mock constructor calls,
 

--- a/example/app/components/Math.brs
+++ b/example/app/components/Math.brs
@@ -3,6 +3,9 @@
 function Math() as Object
   prototype = {}
 
+  prototype.Pi = 3.14159
+  prototype.Tau = 6.28318
+
   prototype.multiply = function (valueA as Integer, valueB as Integer) as Integer
     return valueA * valueB
   end function 

--- a/example/app/components/_tests/mockExamples.test.brs
+++ b/example/app/components/_tests/mockExamples.test.brs
@@ -55,6 +55,28 @@ function TestSuite__mockExamples() as Object
     return expect(funcCallingMultiply()).toBe(0)
   end function)
 
+  it("should be able to mock property value", function () as String
+    ' When
+    mockFunction("Math").setProperty("Pi", 4.123)
+
+    ' Then
+    return expect(funcReturningPi()).toBe(4.123)
+  end function)
+
+  it("should be able to mock multiple property values", function () as Object
+    ' When
+    mockFunction("Math").setProperties({
+      Pi: 10.1112,
+      Tau: 55555.1,
+    })
+
+    ' Then
+    return [
+      expect(funcReturningPi()).toBe(10.1112),
+      expect(funcReturningTau()).toBe(55555.1),
+    ]
+  end function)
+
   ' This test needs to be at the bottom
   it("should clear all mock calls from previous tests", function () as Object
     ' Then

--- a/example/app/components/mockExamples.brs
+++ b/example/app/components/mockExamples.brs
@@ -16,5 +16,13 @@ function funcCallingMultiply(aValue = 1 as Integer, bValue = 2 as Integer) as In
   return Math().multiply(aValue, bValue)
 end function
 
+function funcReturningPi() as Float
+  return Math().Pi
+end function
+
+function funcReturningTau() as Float
+  return Math().Tau
+end function
+
 function funcNotCallingSum()
 end function

--- a/src/components/KopytkoMockFunction.brs
+++ b/src/components/KopytkoMockFunction.brs
@@ -34,11 +34,23 @@ function mockFunction(functionName as String) as Object
   end function
 
   ' ----------------------------------------------------------------
+  ' [DEPRECATED] This method name has been misspelled and will be removed in the future
   ' Returns mock constructor calls
   '
   ' @return An array with function calls
   ' ----------------------------------------------------------------
   context.getContructorCalls = function () as Object
+    print "getContructorCalls is DEPRECATED, please use correct version - getConstructorCalls"
+
+    return m._ts.getProperty(GetGlobalAA()["__mocks"], m._functionName + ".constructorCalls", [])
+  end function
+
+  ' ----------------------------------------------------------------
+  ' Returns mock constructor calls
+  '
+  ' @return An array with function constructor calls
+  ' ----------------------------------------------------------------
+  context.getConstructorCalls = function () as Object
     return m._ts.getProperty(GetGlobalAA()["__mocks"], m._functionName + ".constructorCalls", [])
   end function
 
@@ -97,6 +109,33 @@ function mockFunction(functionName as String) as Object
       ]
       throw error.join(Chr(10))
     end if
+  end sub
+
+  ' ----------------------------------------------------------------
+  ' Mocks function set of properties
+  '
+  ' @param properties (object) - Properties Associative Array
+  ' ----------------------------------------------------------------
+  context.setProperties = sub (properties as Object)
+    if (m._mock.properties = Invalid)
+      m._mock.properties = {}
+    end if
+
+    m._mock.properties.append(properties)
+  end sub
+
+  ' ----------------------------------------------------------------
+  ' Mocks function property
+  '
+  ' @param name (string) - Property name
+  ' @param value (dynamic) - Property value
+  ' ----------------------------------------------------------------
+  context.setProperty = sub (name as String, value as Dynamic)
+    if (m._mock.properties = Invalid)
+      m._mock.properties = {}
+    end if
+
+    m._mock.properties[name] = value
   end sub
 
   ' ----------------------------------------------------------------

--- a/src/components/KopytkoMockFunction.brs
+++ b/src/components/KopytkoMockFunction.brs
@@ -34,7 +34,7 @@ function mockFunction(functionName as String) as Object
   end function
 
   ' ----------------------------------------------------------------
-  ' [DEPRECATED] This method name has been misspelled and will be removed in the future
+  ' @deprecated This method name has been misspelled and will be removed in the future
   ' Returns mock constructor calls
   '
   ' @return An array with function calls


### PR DESCRIPTION
## What did you implement:

It allows using mockFunction in order to mock properties of the mocked function.

Also, the proper name of `getConstructorCalls` method was introduced and the previous one was set as Deprecated.

## How did you implement it:

By adding `setProperty` and `setProperties` methods to the `mockFunction`.

## How can we verify it:

By following unit tests:

```brs
  it("should be able to mock property value", function () as String
    ' When
    mockFunction("Math").setProperty("Pi", 4.123)

    ' Then
    return expect(funcReturningPi()).toBe(4.123)
  end function)

  it("should be able to mock multiple property values", function () as Object
    ' When
    mockFunction("Math").setProperties({
      Pi: 10.1112,
      Tau: 55555.1,
    })

    ' Then
    return [
      expect(funcReturningPi()).toBe(10.1112),
      expect(funcReturningTau()).toBe(55555.1),
    ]
  end function)
```

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
