### PR TITLE
fix: Mock identifiers collisions

### DIFF
--- a/plugins/generate-tests/import-unit-testing-dependencies/helpers/generate-dependency-identifier.js
+++ b/plugins/generate-tests/import-unit-testing-dependencies/helpers/generate-dependency-identifier.js
@@ -1,7 +1,12 @@
+const getModulePrefixByFilePath = require('@dazn/kopytko-packager/src/plugin-helpers/module/get-module-prefix-by-file-path');
+
 const FILE_NAME_REGEX = /[^/]+.brs/;
 
 module.exports = function generateDependencyIdentifier(dependency) {
-  return dependency.match(FILE_NAME_REGEX)[0]
+  const fileIdentifier = dependency.match(FILE_NAME_REGEX)[0]
     .replace(/[.]|mock|brs/g, '')
     .toLowerCase();
+  const modulePrefix = getModulePrefixByFilePath(dependency);
+
+  return modulePrefix ? `${modulePrefix}/${fileIdentifier}` : fileIdentifier;
 }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-unit-testing-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When a file with the same name exists in more than one module and all these files are imported into one XML file but one of them is mocked, currently, all these file imports are replaced by a single mock import.

My real-life example:
I was updating tests for HttpService for KopytkoFramework. KopytkoTestSuite imports `/components/_testUtils/getType.brs` (so it's an internal KopytkoUnitTestingFramework's copy of KopytkoUtil's getType file). HttpService imports KopytkoUtils' getType.brs file and for testing purposes we mock it.
I wanted to switch to the latest `expect`-based assertions for HttpService tests, but KopytkoExpect uses the getType function. Because of the issue I described, it was replaced by mocked getType function and tests were crashing.

## How did you implement it:

To avoid such collision I added prefixing the dependency identifier with its module name.

## How can we verify it:

You can locally update this file in any repository using this unit testing framework and notice unit tests are still passing.

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
