### PR TITLE
fix: extend telnet timeout for connection

### DIFF
--- a/packager-steps/verify-tests-result/test-results-fetcher.js
+++ b/packager-steps/verify-tests-result/test-results-fetcher.js
@@ -11,7 +11,7 @@ module.exports = class TestResultsFetcher {
     timeout: 'Telnet connection timeout',
   }
   _CONNECTION_PORT = 8085;
-  _CONNECTION_TIMEOUT = 20000;
+  _CONNECTION_TIMEOUT = 60000;
 
   _connection = null;
   _outputInterpreter;


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-unit-testing-framework/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Extends telnet wait time to 60 seconds for an initial connection at the launch of the tests.

For some older devices in connection with some applications where there are already a lot of unit tests written which extends the size of the package by a significant amount, 20 seconds is not enough to launch the testing app.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
